### PR TITLE
11 create enums for item and output type

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@
 	- The song page must exist for it to work. Otherwise, it will throw an exception
 
 - The output method can be changed with command line flag `-o`. This can take either of four values: `STD`, `FILE`, `CLIP`, or `NONE`
-	- std : print lyrics to standard output
-	- file : write lyrics to a file in the current directory (suffixed `.OUT`)
+	- STD : print lyrics to standard output
+	- FILE : write lyrics to a file in the current directory (suffixed `.OUT`)
 		- e.g. `python3 genius_scrape_cli.py -i ALBUM -o FILE` -> `Lefa` `Monsieur Fall`
 		- this will search all the songs in the album "Monsieur Fall", and save the lyrics of each to separate plaintext files
-	- clip : writes the lyrics into the clipboard (next paste action will paste lyrics)
+	- CLIP : writes the lyrics into the clipboard (next paste action will paste lyrics)
 		- when used in conjunction with `-i ALBUM`, it will pause between each song, promtping for any key to be pressed before continuing
 		- **WARNING**: this will overwrite the existing clipboard entry
-	- none : do not output lyrics (used for debug purposes)
+	- NONE : do not output lyrics (used for debug purposes)
 

--- a/README.md
+++ b/README.md
@@ -14,21 +14,21 @@
 - Clone the repository
 - For argument help, run `python3 genius_scrape_cli.py -h`
 - Search for an individual song:
-	- Run `python3 genius_scrape_cli.py` then follow the prompts
-	- e.g. `python3 genius_scrape_cli.py` -> "Lefa" "Tournee des bars" (quotes for clarity)
+	- Run `python3 genius_scrape_cli.py` then enter the artist name, press enter, then enter the item name
+	- e.g. `python3 genius_scrape_cli.py` -> `Lefa` `Tournee des bars`
 - Search for an album:
 	- Run `python3 genius_scrape_cli.py -i ALBUM` then follow the prompts
-	- e.g. `python3 genius_scrape_cli.py` -> "Lefa" "Monsieur Fall" (quotes for clarity)
+	- e.g. `python3 genius_scrape_cli.py` -> `Lefa` `Monsieur Fall`
 - Notes
 	- The names are case insensitive, but may only contain alphanumerics, spaces, and dashes
 - This will try to open the Genius page for that artist/song combination and print the lyrics to standard output
 	- The song page must exist for it to work. Otherwise, it will throw an exception
 
-- The output method can be changed with command line flag `-o`. This can take either of three values: "STD", "FILE", "CLIP", or "NONE" (quotes for clarity)
+- The output method can be changed with command line flag `-o`. This can take either of four values: `STD`, `FILE`, `CLIP`, or `NONE`
 	- std : print lyrics to standard output
 	- file : write lyrics to a file in the current directory (suffixed `.OUT`)
-		- e.g. `python3 genius_scrape_cli.py -i ALBUM -o FILE` -> "Lefa" "Monsieur Fall" (quotes for clarity)
-		- this will search all the songs in Monsieur Fall, and save the lyrics of each to separate plaintext files
+		- e.g. `python3 genius_scrape_cli.py -i ALBUM -o FILE` -> `Lefa` `Monsieur Fall`
+		- this will search all the songs in the album "Monsieur Fall", and save the lyrics of each to separate plaintext files
 	- clip : writes the lyrics into the clipboard (next paste action will paste lyrics)
 		- when used in conjunction with `-i ALBUM`, it will pause between each song, promtping for any key to be pressed before continuing
 		- **WARNING**: this will overwrite the existing clipboard entry

--- a/README.md
+++ b/README.md
@@ -17,19 +17,20 @@
 	- Run `python3 genius_scrape_cli.py` then follow the prompts
 	- e.g. `python3 genius_scrape_cli.py` -> "Lefa" "Tournee des bars" (quotes for clarity)
 - Search for an album:
-	- Run `python3 genius_scrape_cli.py -i album` then follow the prompts
+	- Run `python3 genius_scrape_cli.py -i ALBUM` then follow the prompts
 	- e.g. `python3 genius_scrape_cli.py` -> "Lefa" "Monsieur Fall" (quotes for clarity)
 - Notes
 	- The names are case insensitive, but may only contain alphanumerics, spaces, and dashes
 - This will try to open the Genius page for that artist/song combination and print the lyrics to standard output
 	- The song page must exist for it to work. Otherwise, it will throw an exception
 
-- The output method can be changed with command line flag `-o`. This can take either of three values: "std", "file", "clip", or "none" (quotes for clarity)
+- The output method can be changed with command line flag `-o`. This can take either of three values: "STD", "FILE", "CLIP", or "NONE" (quotes for clarity)
 	- std : print lyrics to standard output
 	- file : write lyrics to a file in the current directory (suffixed `.OUT`)
-		- e.g. `python3 genius_scrape_cli.py -i album -o file` -> "Lefa" "Monsieur Fall" (quotes for clarity)
+		- e.g. `python3 genius_scrape_cli.py -i ALBUM -o FILE` -> "Lefa" "Monsieur Fall" (quotes for clarity)
 		- this will search all the songs in Monsieur Fall, and save the lyrics of each to separate plaintext files
-	- clip : writes the lyrics into the clipboard (next paste action will paste lyrics) 
-		- when used in conjunction with `-i album`, it will pause between each song, promtping for any key to be pressed before continuing
+	- clip : writes the lyrics into the clipboard (next paste action will paste lyrics)
+		- when used in conjunction with `-i ALBUM`, it will pause between each song, promtping for any key to be pressed before continuing
 		- **WARNING**: this will overwrite the existing clipboard entry
 	- none : do not output lyrics (used for debug purposes)
+

--- a/genius_scrape/config.py
+++ b/genius_scrape/config.py
@@ -6,3 +6,4 @@ GENIUS_SITE = "https://genius.com"
 
 global DEBUG
 DEBUG = False
+

--- a/genius_scrape/config.py
+++ b/genius_scrape/config.py
@@ -6,4 +6,3 @@ GENIUS_SITE = "https://genius.com"
 
 global DEBUG
 DEBUG = False
-

--- a/genius_scrape/enums.py
+++ b/genius_scrape/enums.py
@@ -1,40 +1,12 @@
 from enum import Enum
+
 class ItemType(Enum):
     SONG = 1
     ALBUM = 2
-
-#     # methods for argparse
-#     def __str__(self):
-#         return self.name.lower()
-# 
-#     def __repr__(self):
-#         return str(self)
-# 
-#     @staticmethod
-#     def argparse(s):
-#         try:
-#             return ItemType[s.upper()]
-#         except KeyError:
-#             return s
-
 
 class OutputType(Enum):
     STD = 1
     CLIP = 2
     FILE = 3
     NONE = 4
-
-#     # methods for argparse
-#     def __str__(self):
-#         return self.name.lower()
-# 
-#     def __repr__(self):
-#         return str(self)
-# 
-#     @staticmethod
-#     def argparse(s):
-#         try:
-#             return OutputType[s.upper()]
-#         except KeyError:
-#             return s
 

--- a/genius_scrape/enums.py
+++ b/genius_scrape/enums.py
@@ -1,0 +1,40 @@
+from enum import Enum
+class ItemType(Enum):
+    SONG = 1
+    ALBUM = 2
+
+#     # methods for argparse
+#     def __str__(self):
+#         return self.name.lower()
+# 
+#     def __repr__(self):
+#         return str(self)
+# 
+#     @staticmethod
+#     def argparse(s):
+#         try:
+#             return ItemType[s.upper()]
+#         except KeyError:
+#             return s
+
+
+class OutputType(Enum):
+    STD = 1
+    CLIP = 2
+    FILE = 3
+    NONE = 4
+
+#     # methods for argparse
+#     def __str__(self):
+#         return self.name.lower()
+# 
+#     def __repr__(self):
+#         return str(self)
+# 
+#     @staticmethod
+#     def argparse(s):
+#         try:
+#             return OutputType[s.upper()]
+#         except KeyError:
+#             return s
+

--- a/genius_scrape/enums.py
+++ b/genius_scrape/enums.py
@@ -1,12 +1,13 @@
 from enum import Enum
 
+
 class ItemType(Enum):
     SONG = 1
     ALBUM = 2
+
 
 class OutputType(Enum):
     STD = 1
     CLIP = 2
     FILE = 3
     NONE = 4
-

--- a/genius_scrape/genius_scrape.py
+++ b/genius_scrape/genius_scrape.py
@@ -141,7 +141,7 @@ def get_genius_album(artist, album, out):
     """
     For each song in an album, call get_genius_lyrics_from_site and handle output
     """
-    
+
     # Set up the scraper
     site = format_genius_site(artist, album, enums.ItemType.ALBUM)
     page = utils.scraper_setup(site)
@@ -199,3 +199,4 @@ def write_lyrics(lyrics, out, index=0, site=""):
         pass
     else:
         print(lyrics)
+

--- a/genius_scrape/genius_scrape.py
+++ b/genius_scrape/genius_scrape.py
@@ -163,7 +163,7 @@ def get_genius_album(artist, album, out):
             write_lyrics(lyrics, out, i, site)
 
             # so the clipboard doesn't get overwritten
-            if out is enums.OutputType.FILE:
+            if out is enums.OutputType.CLIP:
                 input("Press enter to continue ({}/{})".format(i + 1, len(all_links)))
 
 

--- a/genius_scrape/genius_scrape.py
+++ b/genius_scrape/genius_scrape.py
@@ -63,15 +63,18 @@ def format_genius_site(artist, item, item_type):
     Note: this may break if Genius changes the way they construct their URLs
     """
 
-    print("formatting genius site with artist: {}, item: {}, type: {}".format(artist, item, item_type))
+    if config.DEBUG:
+        print("\tconfig.DEBUG: formatting genius site with artist: {}, item: {}, type: {}".format(artist, item, item_type))
 
     name = format_name(artist, item, item_type)
-    print("name = {}".format(name))
+    if config.DEBUG:
+        print("\tconfig.DEBUG: Name = {}".format(name))
     if item_type is enums.ItemType.ALBUM:
         site = "{GS}/albums/{name}".format(GS=config.GENIUS_SITE, name=name)
     else:
         site = "{GS}/{name}-lyrics".format(GS=config.GENIUS_SITE, name=name)
-    print("site = {}".format(site))
+    if config.DEBUG:
+        print("\tconfig.DEBUG: Site = {}".format(site))
     return site
 
 
@@ -186,7 +189,10 @@ def write_lyrics(lyrics, out, index=0, site=""):
         # Add song-numbers (according to the order they were passed,
         # not their actual position in the album) zero-padded (width=2)
         name = site.rsplit('/', 2)
-        print("output file name = {}".format(name))
+
+        if config.DEBUG:
+            print("\tconfig.DEBUG: Output file name = {}".format(name))
+
         artist = name[1]
         title = name[2]
         with open("{n}-{artist}-{title}.OUT".format(n=str(index).zfill(2), artist=artist, title=title), "w") as f:

--- a/genius_scrape/genius_scrape.py
+++ b/genius_scrape/genius_scrape.py
@@ -64,7 +64,8 @@ def format_genius_site(artist, item, item_type):
     """
 
     if config.DEBUG:
-        print("\tconfig.DEBUG: formatting genius site with artist: {}, item: {}, type: {}".format(artist, item, item_type))
+        print("\tconfig.DEBUG: formatting genius site with artist: {}, item: {}, type: {}".format(
+            artist, item, item_type))
 
     name = format_name(artist, item, item_type)
     if config.DEBUG:
@@ -205,4 +206,3 @@ def write_lyrics(lyrics, out, index=0, site=""):
         pass
     else:
         print(lyrics)
-

--- a/genius_scrape/utils.py
+++ b/genius_scrape/utils.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import re
 import requests
 import sys  # getting os
@@ -27,7 +29,7 @@ def convert_line_endings(temp):
 
 def convert_quote_types(temp):
     """
-    Convert inverted commas â€œâ€�, and â€˜â€™ to straight quotes "" and ''
+    Convert inverted commas “”, and ‘’ to straight quotes "" and ''
     """
 
     u = unidecode(temp)
@@ -38,7 +40,7 @@ def convert_quote_types(temp):
 
 def scraper_setup(site):
     """
-    site: string url of site wanting to be scraped
+    site: string url of site to be scraped
     returns a page, or exits early if an error occurs
     """
     print("[[ About to search {site} ]]".format(site=site))

--- a/genius_scrape/utils.py
+++ b/genius_scrape/utils.py
@@ -59,4 +59,3 @@ def scraper_setup(site):
         exit(3)
     else:
         return page
-

--- a/genius_scrape/utils.py
+++ b/genius_scrape/utils.py
@@ -59,3 +59,4 @@ def scraper_setup(site):
         exit(3)
     else:
         return page
+

--- a/genius_scrape_cli.py
+++ b/genius_scrape_cli.py
@@ -84,3 +84,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/genius_scrape_cli.py
+++ b/genius_scrape_cli.py
@@ -87,4 +87,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/genius_scrape_cli.py
+++ b/genius_scrape_cli.py
@@ -28,7 +28,6 @@ def argparse_setup():
 
     parser.add_argument(
         "-i", "--item",
-        # type=enums.ItemType.__getitem__,
         default='SONG',
         choices=enums.ItemType.__members__,
         help="the type of item to search for (default: song)"
@@ -36,7 +35,6 @@ def argparse_setup():
 
     parser.add_argument(
         "-o", "--output",
-        # type=enums.OutputType.__getitem__,
         default='STD',
         choices=enums.OutputType.__members__,
         help="how to handle output (default: STD)"
@@ -61,8 +59,6 @@ def main():
     config.DEBUG = args.debug
 
     # Prompt for input
-    # artist = input("Enter the artist: ")
-    # item = input("Enter the {item_type}".format(item_type=args.item))
     artist = input()
     item = input()
 

--- a/genius_scrape_cli.py
+++ b/genius_scrape_cli.py
@@ -4,6 +4,7 @@ import argparse  # Multi-word song names or artists
 import textwrap
 
 from genius_scrape import config
+from genius_scrape import enums
 from genius_scrape import genius_scrape
 
 
@@ -27,20 +28,24 @@ def argparse_setup():
 
     parser.add_argument(
         "-i", "--item",
-        default="song",
-        choices=["album", "song"],
+        # type=enums.ItemType.__getitem__,
+        default='SONG',
+        choices=enums.ItemType.__members__,
         help="the type of item to search for (default: song)"
     )
+
     parser.add_argument(
         "-o", "--output",
-        default="std",
-        choices=["std", "file", "clip", "none"],
+        # type=enums.OutputType.__getitem__,
+        default='STD',
+        choices=enums.OutputType.__members__,
         help="how to handle output (default: std)"
         # std  : output to standard output
         # file : output to a file
         # clip : add output to a new clipboard entry
         # none : do not output lyrics (for debug purposes)
     )
+
     parser.add_argument(
         "-d", "--debug",
         help="show debug outputs",
@@ -61,11 +66,18 @@ def main():
     artist = input()
     item = input()
 
+    # convert from input string to enum
+    args.item = enums.ItemType[args.item]
+    args.output = enums.OutputType[args.output]
+
+    print("item: {}, output: {}".format(args.item, args.output))
     # Retrieve lyrics
-    if args.item == "song":
+    if args.item is enums.ItemType.SONG:
+        print('treating as a song')
         lyrics = genius_scrape.get_genius_lyrics_from_parts(artist, item)
         genius_scrape.write_lyrics(lyrics, args.output)
-    else:
+    elif args.item is enums.ItemType.ALBUM:
+        print('treating as an album')
         genius_scrape.get_genius_album(artist, item, args.output)
     return 0
 

--- a/genius_scrape_cli.py
+++ b/genius_scrape_cli.py
@@ -39,11 +39,11 @@ def argparse_setup():
         # type=enums.OutputType.__getitem__,
         default='STD',
         choices=enums.OutputType.__members__,
-        help="how to handle output (default: std)"
-        # std  : output to standard output
-        # file : output to a file
-        # clip : add output to a new clipboard entry
-        # none : do not output lyrics (for debug purposes)
+        help="how to handle output (default: STD)"
+        # STD  : output to standard output
+        # FILE : output to a file
+        # CLIP : add output to a new clipboard entry
+        # NONE : do not output lyrics (for debug purposes)
     )
 
     parser.add_argument(
@@ -80,7 +80,7 @@ def main():
         genius_scrape.write_lyrics(lyrics, args.output)
     elif args.item is enums.ItemType.ALBUM:
         if config.DEBUG:
-            print(l"\tconfig.DEBUG: treating as an album")
+            print("\tconfig.DEBUG: treating as an album")
         genius_scrape.get_genius_album(artist, item, args.output)
     return 0
 

--- a/genius_scrape_cli.py
+++ b/genius_scrape_cli.py
@@ -70,14 +70,17 @@ def main():
     args.item = enums.ItemType[args.item]
     args.output = enums.OutputType[args.output]
 
-    print("item: {}, output: {}".format(args.item, args.output))
+    if config.DEBUG:
+        print("\tconfig.DEBUG: item: {}, output: {}".format(args.item, args.output))
     # Retrieve lyrics
     if args.item is enums.ItemType.SONG:
-        print('treating as a song')
+        if config.DEBUG:
+            print("\tconfig.DEBUG: treating as a song")
         lyrics = genius_scrape.get_genius_lyrics_from_parts(artist, item)
         genius_scrape.write_lyrics(lyrics, args.output)
     elif args.item is enums.ItemType.ALBUM:
-        print('treating as an album')
+        if config.DEBUG:
+            print(l"\tconfig.DEBUG: treating as an album")
         genius_scrape.get_genius_album(artist, item, args.output)
     return 0
 

--- a/genius_scrape_gui.py
+++ b/genius_scrape_gui.py
@@ -89,4 +89,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/genius_scrape_gui.py
+++ b/genius_scrape_gui.py
@@ -80,3 +80,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/genius_scrape_gui.py
+++ b/genius_scrape_gui.py
@@ -57,13 +57,17 @@ class GeniusScrapeGui:
         Makes calls to the genius_scrape module
         """
 
+        # Take user input
         artist = self.artist_input.get().lower()
         item = self.item_input.get().lower()
+
+        # Read the options and turn them into the enum value
         item_type_str = self.item_type_variable.get()
         item_type = enums.ItemType[item_type_str]
         output_str = self.output_variable.get()
         output = enums.OutputType[output_str]
 
+        # Check the inputs have been populated
         if not artist:
             print("artist field must be filled in")
             return

--- a/genius_scrape_gui.py
+++ b/genius_scrape_gui.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from tkinter import Button
 from tkinter import Entry
 from tkinter import Label
@@ -5,6 +7,7 @@ from tkinter import OptionMenu
 from tkinter import StringVar
 from tkinter import Tk
 
+from genius_scrape import enums
 from genius_scrape import genius_scrape
 
 
@@ -26,7 +29,7 @@ class GeniusScrapeGui:
         self.artist_input.grid(column=1, row=0)
         self.artist_input.focus()
 
-        self.item_type_options = ["Song", "Album"]
+        self.item_type_options = ["SONG", "ALBUM"]
         self.item_type_variable = StringVar(self.window)
         self.item_type_variable.set(self.item_type_options[0])
         self.item_type_dropdown = OptionMenu(
@@ -36,7 +39,7 @@ class GeniusScrapeGui:
         self.item_input = Entry(self.window, width=30)
         self.item_input.grid(column=1, row=1)
 
-        self.output_options = ["std", "file", "clip"]
+        self.output_options = ["STD", "FILE", "CLIP"]
         self.output_variable = StringVar(self.window)
         self.output_variable.set(self.output_options[0])
         self.output_dropdown = OptionMenu(
@@ -56,8 +59,10 @@ class GeniusScrapeGui:
 
         artist = self.artist_input.get().lower()
         item = self.item_input.get().lower()
-        item_type = self.item_type_variable.get().lower()
-        output = self.output_variable.get().lower()
+        item_type_str = self.item_type_variable.get()
+        item_type = enums.ItemType[item_type_str]
+        output_str = self.output_variable.get()
+        output = enums.OutputType[output_str]
 
         if not artist:
             print("artist field must be filled in")
@@ -67,7 +72,7 @@ class GeniusScrapeGui:
             return
 
         # Retrieve lyrics
-        if item_type == "song":
+        if item_type is enums.ItemType.SONG:
             lyrics = genius_scrape.get_genius_lyrics_from_parts(artist, item)
             genius_scrape.write_lyrics(lyrics, output)
         else:

--- a/tests/test_genius_scrape.py
+++ b/tests/test_genius_scrape.py
@@ -1,4 +1,6 @@
 import unittest
+
+from genius_scrape import enums
 from genius_scrape import genius_scrape
 
 
@@ -21,7 +23,7 @@ class TestGeniusScrape(unittest.TestCase):
 
         for i in album_tests.items():
             self.assertEqual(genius_scrape.format_name(
-                i[0][0], i[0][1], "album"), i[1])
+                i[0][0], i[0][1], enums.ItemType.ALBUM), i[1])
 
     def test_format_name_song(self):
 
@@ -37,7 +39,7 @@ class TestGeniusScrape(unittest.TestCase):
 
         for i in song_tests.items():
             self.assertEqual(genius_scrape.format_name(
-                i[0][0], i[0][1], "song"), i[1])
+                i[0][0], i[0][1], enums.ItemType.SONG), i[1])
 
     def test_format_genius_site_album(self):
 
@@ -56,7 +58,7 @@ class TestGeniusScrape(unittest.TestCase):
 
         for i in album_tests.items():
             self.assertEqual(genius_scrape.format_genius_site(
-                i[0][0], i[0][1], "album"), i[1])
+                i[0][0], i[0][1], enums.ItemType.ALBUM), i[1])
 
     def test_format_genius_site_song(self):
 
@@ -72,7 +74,7 @@ class TestGeniusScrape(unittest.TestCase):
 
         for i in song_tests.items():
             self.assertEqual(genius_scrape.format_genius_site(
-                i[0][0], i[0][1], "song"), i[1])
+                i[0][0], i[0][1], enums.ItemType.SONG), i[1])
 
     def test_is_song_happy(self):
 


### PR DESCRIPTION
closes #11 

- applied to both cli and gui clients
- cmd line options for item and output type now use CAPITALS
  - e.g. `-i SONG -o FILE`
- in the code, the enums are included using `from genius_scrape import enums` and used with `enums.BlahType.ENUM_VALUE`